### PR TITLE
Remove hardcoding of faction logo placement

### DIFF
--- a/InnerSphereMap/InnerSphereMap/HolderClasses.cs
+++ b/InnerSphereMap/InnerSphereMap/HolderClasses.cs
@@ -5,51 +5,6 @@ using UnityEngine;
 
 namespace InnerSphereMap {
     public class Settings {
-        public List<float> KuritaRGB;
-        public List<float> SteinerRGB;
-        public List<float> OutworldsRGB;
-        public List<float> OberonRGB;
-        public List<float> LothianRGB;
-        public List<float> MarianRGB;
-        public List<float> CircinusRGB;
-        public List<float> IllyrianRGB;
-        public List<float> DavionRGB;
-        public List<float> LiaoRGB;
-        public List<float> MarikRGB;
-        public List<float> TaurianRGB;
-        public List<float> MagistracyRGB;
-        public List<float> RestorationRGB;
-        public List<float> RasalhagueRGB;
-        public List<float> StIvesRGB;
-        public List<float> AbandonedRGB;
-        public List<float> MRBRGB;
-        public List<float> ComStarRGB;
-        public List<float> CastileRGB;
-        public List<float> ChainelaneRGB;
-        public List<float> ClanBurrockRGB;
-        public List<float> ClanCloudCobraRGB;
-        public List<float> ClanCoyoteRGB;
-        public List<float> ClanDiamondSharkRGB;
-        public List<float> ClanFireMandrillRGB;
-        public List<float> ClanGhostBearRGB;
-        public List<float> ClanGoliathScorpionRGB;
-        public List<float> ClanHellsHorsesRGB;
-        public List<float> ClanIceHellionRGB;
-        public List<float> ClanJadeFalconRGB;
-        public List<float> ClanNovaCatRGB;
-        public List<float> ClansGenericRGB;
-        public List<float> ClanSmokeJaguarRGB;
-        public List<float> ClanSnowRavenRGB;
-        public List<float> ClanStarAdderRGB;
-        public List<float> ClanSteelViperRGB;
-        public List<float> ClanWolfRGB;
-        public List<float> DelphiRGB;
-        public List<float> ElysiaRGB;
-        public List<float> HanseRGB;
-        public List<float> JarnFolkRGB;
-        public List<float> TortugaRGB;
-        public List<float> ValkyrateRGB;
-        public List<float> AxumiteRGB;
 
         public float MinFov; // this is the vertical FOV
         public float MaxFov; // this is the vertical FOV
@@ -68,8 +23,15 @@ namespace InnerSphereMap {
         public string splashText = "";
         public List<string> cheatcodes = new List<string>();
 
-        
+        public List<LogoItem> logos = new List<LogoItem>();
+        public bool reducedClanLogos = true;    
 
+    }
+
+    public class LogoItem
+    {
+        public string factionName = "";
+        public string logoImage = "";
     }
 
     public class Fields {

--- a/InnerSphereMap/InnerSphereMap/Patch.cs
+++ b/InnerSphereMap/InnerSphereMap/Patch.cs
@@ -181,20 +181,20 @@ namespace InnerSphereMap {
         }
         static void Postfix(StarmapRenderer __instance) {
             try {
-                //var davionLogo = GameObject.Find("davionLogo");
-                //var marikLogo = GameObject.Find("marikLogo");
-                //var directorateLogo = GameObject.Find("directorateLogo");
-                //directorateLogo?.SetActive(false);
-                //davionLogo?.SetActive(false);
-                //marikLogo?.SetActive(false);
-                //var liaoLogo = GameObject.Find("liaoLogo");
-                //liaoLogo?.SetActive(false);
-                //var taurianLogo = GameObject.Find("taurianLogo");
-                //taurianLogo?.SetActive(false);
-                //var magistracyLogo = GameObject.Find("magistracyLogo");
-                //magistracyLogo?.SetActive(false);
-                //var restorationLogo = GameObject.Find("restorationLogo");
-                //restorationLogo?.SetActive(false);
+                var davionLogo = GameObject.Find("davionLogo");
+                var marikLogo = GameObject.Find("marikLogo");
+                var directorateLogo = GameObject.Find("directorateLogo");
+                directorateLogo?.SetActive(false);
+                davionLogo?.SetActive(false);
+                marikLogo?.SetActive(false);
+                var liaoLogo = GameObject.Find("liaoLogo");
+                liaoLogo?.SetActive(false);
+                var taurianLogo = GameObject.Find("taurianLogo");
+                taurianLogo?.SetActive(false);
+                var magistracyLogo = GameObject.Find("magistracyLogo");
+                magistracyLogo?.SetActive(false);
+                var restorationLogo = GameObject.Find("restorationLogo");
+                restorationLogo?.SetActive(false);
 
                 GameObject go;
                 if (Fields.originalTransform == null) {
@@ -202,432 +202,499 @@ namespace InnerSphereMap {
                 }
                 Texture2D texture2D2;
                 byte[] data;
-                //if (GameObject.Find("davionLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/davionLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "davionLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("davionLogoMap");
+                if (GameObject.Find("davionLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/davionLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "davionLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("davionLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Davion, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Davion"), go });
 
-                //if (GameObject.Find("liaoLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/liaoLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "liaoLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("liaoLogoMap");
+                if (GameObject.Find("liaoLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/liaoLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "liaoLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("liaoLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Liao, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Liao"), go });
 
-                //if (GameObject.Find("magistracyLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/magistracyLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "magistracyLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("magistracyLogoMap");
+                if (GameObject.Find("magistracyLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/magistracyLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "magistracyLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("magistracyLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.MagistracyOfCanopus, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("MagistracyOfCanopus"), go });
 
-                //if (GameObject.Find("marikLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marikLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "marikLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("marikLogoMap");
+                if (GameObject.Find("marikLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marikLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "marikLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("marikLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Marik, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Marik"), go });
 
-                //if (GameObject.Find("restorationLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/restorationLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "restorationLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("restorationLogoMap");
+                if (GameObject.Find("restorationLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/restorationLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "restorationLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("restorationLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.AuriganRestoration, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("AuriganRestoration"), go });
 
-                //if (GameObject.Find("taurianLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/taurianLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "taurianLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("taurianLogoMap");
+                if (GameObject.Find("taurianLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/taurianLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "taurianLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("taurianLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.TaurianConcordat, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("TaurianConcordat"), go });
 
-                //if (GameObject.Find("steinerLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/steinerLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "steinerLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("steinerLogoMap");
+                if (GameObject.Find("steinerLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/steinerLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "steinerLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("steinerLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Steiner, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Steiner"), go });
 
-                //if (GameObject.Find("draconisLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/draconisLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "draconisLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("draconisLogoMap");
+                if (GameObject.Find("draconisLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/draconisLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "draconisLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("draconisLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Kurita, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Kurita"), go });
 
-                //if (GameObject.Find("circinusLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/circinusLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "circinusLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("circinusLogoMap");
+                if (GameObject.Find("circinusLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/circinusLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "circinusLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("circinusLogoMap");
 
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Circinus, go });
-
-
-                //if (GameObject.Find("oberonLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/oberonLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "oberonLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("oberonLogoMap");
-
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Oberon, go });
-
-
-                //if (GameObject.Find("rasalhagueLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/rasalhagueLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "rasalhagueLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("rasalhagueLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Rasalhague, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Circinus"), go });
 
 
-                //if (GameObject.Find("illyrianLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/illyrianLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "illyrianLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("illyrianLogoMap");
-                //}
+                if (GameObject.Find("oberonLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/oberonLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "oberonLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("oberonLogoMap");
 
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Illyrian, go });
-
-                //if (GameObject.Find("stivesLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/stivesLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "stivesLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("stivesLogoMap");
-
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Ives, go });
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Oberon"), go });
 
 
-                //if (GameObject.Find("lothianLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/lothianLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "lothianLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("lothianLogoMap");
-
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Lothian, go });
-
-                //if (GameObject.Find("marianLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marianLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "marianLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("marianLogoMap");
-
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Marian, go });
-
-                //if (GameObject.Find("outworldsLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/outworldsLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "outworldsLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("outworldsLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Outworld, go });
-
-                //if (GameObject.Find("directorateLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/directorateLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "directorateLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("directorateLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.AuriganDirectorate, go });
-
-                //if (GameObject.Find("AxumiteLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/AxumiteLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "AxumiteLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("AxumiteLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Axumite, go });
-
-                //if (GameObject.Find("CastileLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/CastileLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "CastileLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("CastileLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Castile, go });
-
-                //if (GameObject.Find("WordOfBlakeLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/WordOfBlakeLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "WordOfBlakeLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("WordOfBlakeLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.WordOfBlake, go });
-
-                //if (GameObject.Find("ChainelaneLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ChainelaneLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "ChainelaneLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("ChainelaneLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Chainelane, go });
+                if (GameObject.Find("rasalhagueLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/rasalhagueLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "rasalhagueLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("rasalhagueLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Rasalhague"), go });
 
 
-                //Faction leaderclan = __instance.starmap.GetSystemByID("starsystemdef_StranaMechty").System.Owner;
-                //if (GameObject.Find("ClansGenericLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.ToString() + "Logo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "ClansGenericLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("ClansGenericLogoMap");
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.ToString() + "Logo.png");
-                //    texture2D2 = new Texture2D(2, 2);
-                //    texture2D2.LoadImage(data);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { leaderclan, go });
+                if (GameObject.Find("illyrianLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/illyrianLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "illyrianLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("illyrianLogoMap");
+                }
+
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("llyrian"), go });
+
+                if (GameObject.Find("stivesLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/stivesLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "stivesLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("stivesLogoMap");
+
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Ives"), go });
 
 
-                //SimGameState sim = (SimGameState)AccessTools.Field(typeof(Starmap), "sim").GetValue(__instance.starmap);
-                //List<Faction> contestingFactions = new List<Faction>() { Faction.ClanBurrock, Faction.ClanCloudCobra, Faction.ClanCoyote,
-                //    Faction.ClanDiamondShark, Faction.ClanFireMandrill,Faction.ClanGhostBear,Faction.ClanGoliathScorpion,Faction.ClanHellsHorses,
-                //    Faction.ClanIceHellion,Faction.ClanJadeFalcon,Faction.ClanNovaCat,Faction.ClansGeneric,Faction.ClanSmokeJaguar,Faction.ClanSnowRaven,
-                //    Faction.ClanStarAdder,Faction.ClanSteelViper,Faction.ClanWolf};
-                //Dictionary<Faction, int> ranking = new Dictionary<Faction, int>();
-                //foreach (StarSystem system in sim.StarSystems) {
-                //    if (contestingFactions.Contains(system.Owner)) {
-                //        if (!ranking.ContainsKey(system.Owner)) {
-                //            ranking.Add(system.Owner, 0);
-                //        }
-                //        ranking[system.Owner]++;
-                //    }
-                //}
-                //Faction invaderclan = Faction.INVALID_UNSET;
-                //if (ranking.Count > 0) {
-                //    invaderclan = ranking.OrderByDescending(x => x.Value).First().Key;
-                //}
-                //if (invaderclan != Faction.INVALID_UNSET) {
-                //    if (GameObject.Find("ClansInvaderLogoMap") == null) {
-                //        texture2D2 = new Texture2D(2, 2);
-                //        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.ToString() + "Logo.png");
-                //        texture2D2.LoadImage(data);
-                //        go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //        go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //        go.name = "ClansInvaderLogoMap";
-                //    }
-                //    else {
-                //        go = GameObject.Find("ClansInvaderLogoMap");
-                //        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.ToString() + "Logo.png");
-                //        texture2D2 = new Texture2D(2, 2);
-                //        texture2D2.LoadImage(data);
-                //        go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    }
-                //    ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { invaderclan, go });
-                //}
+                if (GameObject.Find("lothianLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/lothianLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "lothianLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("lothianLogoMap");
+
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Lothian"), go });
+
+                if (GameObject.Find("marianLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marianLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "marianLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("marianLogoMap");
+
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Marian"), go });
+
+                if (GameObject.Find("outworldsLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/outworldsLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "outworldsLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("outworldsLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Outworld"), go });
+
+                if (GameObject.Find("directorateLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/directorateLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "directorateLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("directorateLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("AuriganDirectorate"), go });
+
+                if (GameObject.Find("AxumiteLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/AxumiteLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "AxumiteLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("AxumiteLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Axumite"), go });
+
+                if (GameObject.Find("CastileLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/CastileLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "CastileLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("CastileLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Castile"), go });
+
+                if (GameObject.Find("WordOfBlakeLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/WordOfBlakeLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "WordOfBlakeLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("WordOfBlakeLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("WordOfBlake"), go });
+
+                if (GameObject.Find("ChainelaneLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ChainelaneLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "ChainelaneLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("ChainelaneLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Chainelane"), go });
 
 
-                //if (GameObject.Find("DelphiLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/DelphiLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "DelphiLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("DelphiLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Delphi, go });
+                FactionValue leaderclan = __instance.starmap.GetSystemByID("starsystemdef_StranaMechty").System.OwnerValue;
+                if (GameObject.Find("ClansGenericLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.Name + "Logo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "ClansGenericLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("ClansGenericLogoMap");
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.Name + "Logo.png");
+                    texture2D2 = new Texture2D(2, 2);
+                    texture2D2.LoadImage(data);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { leaderclan, go });
 
-                //if (GameObject.Find("ElysiaLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ElysiaLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "ElysiaLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("ElysiaLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Elysia, go });
 
-                //if (GameObject.Find("HanseLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/HanseLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "HanseLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("HanseLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Hanse, go });
+                SimGameState sim = (SimGameState)AccessTools.Field(typeof(Starmap), "sim").GetValue(__instance.starmap);
+                List<FactionValue> contestingFactions = new List<FactionValue>();
+                foreach (FactionValue faction in FactionEnumeration.FactionList)
+                {
+                    if (faction.IsClan && faction.CanAlly)
+                    {
+                        contestingFactions.Add(faction);
+                    }
+                }
+                Dictionary<FactionValue, int> ranking = new Dictionary<FactionValue, int>();
+                foreach (StarSystem system in sim.StarSystems)
+                {
+                    if (contestingFactions.Contains(system.OwnerValue))
+                    {
+                        if (!ranking.ContainsKey(system.OwnerValue))
+                        {
+                            ranking.Add(system.OwnerValue, 0);
+                        }
+                        ranking[system.OwnerValue]++;
+                    }
+                }
+                FactionValue invaderclan = FactionEnumeration.GetInvalidUnsetFactionValue();
+                if (ranking.Count > 0)
+                {
+                    invaderclan = ranking.OrderByDescending(x => x.Value).First().Key;
+                }
+                if (invaderclan != FactionEnumeration.GetInvalidUnsetFactionValue())
+                {
+                    if (GameObject.Find("ClansInvaderLogoMap") == null)
+                    {
+                        texture2D2 = new Texture2D(2, 2);
+                        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
+                        texture2D2.LoadImage(data);
+                        go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                        go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                        go.name = "ClansInvaderLogoMap";
+                    }
+                    else
+                    {
+                        go = GameObject.Find("ClansInvaderLogoMap");
+                        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
+                        texture2D2 = new Texture2D(2, 2);
+                        texture2D2.LoadImage(data);
+                        go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    }
+                    ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { invaderclan, go });
+                }
 
-                //if (GameObject.Find("JarnFolkLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/JarnFolkLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "JarnFolkLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("JarnFolkLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.JarnFolk, go });
 
-                //if (GameObject.Find("TortugaLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/TortugaLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "TortugaLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("TortugaLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Tortuga, go });
+                if (GameObject.Find("DelphiLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/DelphiLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "DelphiLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("DelphiLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Delphi"), go });
 
-                //if (GameObject.Find("ValkyrateLogoMap") == null) {
-                //    texture2D2 = new Texture2D(2, 2);
-                //    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ValkyrateLogo.png");
-                //    texture2D2.LoadImage(data);
-                //    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                //    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                //    go.name = "ValkyrateLogoMap";
-                //}
-                //else {
-                //    go = GameObject.Find("ValkyrateLogoMap");
-                //}
-                //ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { Faction.Valkyrate, go });
+                if (GameObject.Find("ElysiaLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ElysiaLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "ElysiaLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("ElysiaLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Elysia"), go });
+
+                if (GameObject.Find("HanseLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/HanseLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "HanseLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("HanseLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Hanse"), go });
+
+                if (GameObject.Find("JarnFolkLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/JarnFolkLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "JarnFolkLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("JarnFolkLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("JarnFolk"), go });
+
+                if (GameObject.Find("TortugaLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/TortugaLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "TortugaLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("TortugaLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Tortuga"), go });
+
+                if (GameObject.Find("ValkyrateLogoMap") == null)
+                {
+                    texture2D2 = new Texture2D(2, 2);
+                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ValkyrateLogo.png");
+                    texture2D2.LoadImage(data);
+                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                    go.name = "ValkyrateLogoMap";
+                }
+                else
+                {
+                    go = GameObject.Find("ValkyrateLogoMap");
+                }
+                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Valkyrate"), go });
             }
             catch (Exception e) {
                 Logger.LogError(e);

--- a/InnerSphereMap/InnerSphereMap/Patch.cs
+++ b/InnerSphereMap/InnerSphereMap/Patch.cs
@@ -202,499 +202,83 @@ namespace InnerSphereMap {
                 }
                 Texture2D texture2D2;
                 byte[] data;
-                if (GameObject.Find("davionLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/davionLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "davionLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("davionLogoMap");
 
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Davion"), go });
-
-                if (GameObject.Find("liaoLogoMap") == null)
+                foreach (LogoItem logoItem in InnerSphereMap.SETTINGS.logos)
                 {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/liaoLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "liaoLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("liaoLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Liao"), go });
-
-                if (GameObject.Find("magistracyLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/magistracyLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "magistracyLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("magistracyLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("MagistracyOfCanopus"), go });
-
-                if (GameObject.Find("marikLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marikLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "marikLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("marikLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Marik"), go });
-
-                if (GameObject.Find("restorationLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/restorationLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "restorationLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("restorationLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("AuriganRestoration"), go });
-
-                if (GameObject.Find("taurianLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/taurianLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "taurianLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("taurianLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("TaurianConcordat"), go });
-
-                if (GameObject.Find("steinerLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/steinerLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "steinerLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("steinerLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Steiner"), go });
-
-                if (GameObject.Find("draconisLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/draconisLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "draconisLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("draconisLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Kurita"), go });
-
-                if (GameObject.Find("circinusLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/circinusLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "circinusLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("circinusLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Circinus"), go });
-
-
-                if (GameObject.Find("oberonLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/oberonLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "oberonLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("oberonLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Oberon"), go });
-
-
-                if (GameObject.Find("rasalhagueLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/rasalhagueLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "rasalhagueLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("rasalhagueLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Rasalhague"), go });
-
-
-                if (GameObject.Find("illyrianLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/illyrianLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "illyrianLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("illyrianLogoMap");
-                }
-
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("llyrian"), go });
-
-                if (GameObject.Find("stivesLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/stivesLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "stivesLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("stivesLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Ives"), go });
-
-
-                if (GameObject.Find("lothianLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/lothianLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "lothianLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("lothianLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Lothian"), go });
-
-                if (GameObject.Find("marianLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/marianLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "marianLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("marianLogoMap");
-
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Marian"), go });
-
-                if (GameObject.Find("outworldsLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/outworldsLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "outworldsLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("outworldsLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Outworld"), go });
-
-                if (GameObject.Find("directorateLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/directorateLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "directorateLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("directorateLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("AuriganDirectorate"), go });
-
-                if (GameObject.Find("AxumiteLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/AxumiteLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "AxumiteLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("AxumiteLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Axumite"), go });
-
-                if (GameObject.Find("CastileLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/CastileLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "CastileLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("CastileLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Castile"), go });
-
-                if (GameObject.Find("WordOfBlakeLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/WordOfBlakeLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "WordOfBlakeLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("WordOfBlakeLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("WordOfBlake"), go });
-
-                if (GameObject.Find("ChainelaneLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ChainelaneLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "ChainelaneLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("ChainelaneLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Chainelane"), go });
-
-
-                FactionValue leaderclan = __instance.starmap.GetSystemByID("starsystemdef_StranaMechty").System.OwnerValue;
-                if (GameObject.Find("ClansGenericLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.Name + "Logo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "ClansGenericLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("ClansGenericLogoMap");
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + leaderclan.Name + "Logo.png");
-                    texture2D2 = new Texture2D(2, 2);
-                    texture2D2.LoadImage(data);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { leaderclan, go });
-
-
-                SimGameState sim = (SimGameState)AccessTools.Field(typeof(Starmap), "sim").GetValue(__instance.starmap);
-                List<FactionValue> contestingFactions = new List<FactionValue>();
-                foreach (FactionValue faction in FactionEnumeration.FactionList)
-                {
-                    if (faction.IsClan && faction.CanAlly)
+                    FactionValue factionValue = FactionEnumeration.GetFactionByName(logoItem.factionName);
+                    if (factionValue.IsClan && InnerSphereMap.SETTINGS.reducedClanLogos)
                     {
-                        contestingFactions.Add(faction);
+                        continue;
                     }
-                }
-                Dictionary<FactionValue, int> ranking = new Dictionary<FactionValue, int>();
-                foreach (StarSystem system in sim.StarSystems)
-                {
-                    if (contestingFactions.Contains(system.OwnerValue))
-                    {
-                        if (!ranking.ContainsKey(system.OwnerValue))
-                        {
-                            ranking.Add(system.OwnerValue, 0);
-                        }
-                        ranking[system.OwnerValue]++;
-                    }
-                }
-                FactionValue invaderclan = FactionEnumeration.GetInvalidUnsetFactionValue();
-                if (ranking.Count > 0)
-                {
-                    invaderclan = ranking.OrderByDescending(x => x.Value).First().Key;
-                }
-                if (invaderclan != FactionEnumeration.GetInvalidUnsetFactionValue())
-                {
-                    if (GameObject.Find("ClansInvaderLogoMap") == null)
+                    string mapGoObject = logoItem.factionName + "Map";
+                    if (GameObject.Find(mapGoObject) == null)
                     {
                         texture2D2 = new Texture2D(2, 2);
-                        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
+                        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/{logoItem.logoImage}.png");
                         texture2D2.LoadImage(data);
                         go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
                         go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                        go.name = "ClansInvaderLogoMap";
+                        go.name = mapGoObject;
                     }
                     else
                     {
-                        go = GameObject.Find("ClansInvaderLogoMap");
-                        data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
-                        texture2D2 = new Texture2D(2, 2);
-                        texture2D2.LoadImage(data);
-                        go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                        go = GameObject.Find(mapGoObject);
+
                     }
-                    ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { invaderclan, go });
+                    ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName(logoItem.factionName), go });
                 }
 
+                if (InnerSphereMap.SETTINGS.reducedClanLogos)
+                {
+                    SimGameState sim = (SimGameState)AccessTools.Field(typeof(Starmap), "sim").GetValue(__instance.starmap);
+                    List<FactionValue> contestingFactions = new List<FactionValue>();
+                    foreach (FactionValue faction in FactionEnumeration.FactionList)
+                    {
+                        if (faction.IsClan && faction.CanAlly)
+                        {
+                            contestingFactions.Add(faction);
+                        }
+                    }
+                    Dictionary<FactionValue, int> ranking = new Dictionary<FactionValue, int>();
+                    foreach (StarSystem system in sim.StarSystems)
+                    {
+                        if (contestingFactions.Contains(system.OwnerValue))
+                        {
+                            if (!ranking.ContainsKey(system.OwnerValue))
+                            {
+                                ranking.Add(system.OwnerValue, 0);
+                            }
+                            ranking[system.OwnerValue]++;
+                        }
+                    }
+                    FactionValue invaderclan = FactionEnumeration.GetInvalidUnsetFactionValue();
+                    if (ranking.Count > 0)
+                    {
+                        invaderclan = ranking.OrderByDescending(x => x.Value).First().Key;
+                    }
+                    if (invaderclan != FactionEnumeration.GetInvalidUnsetFactionValue())
+                    {
+                        if (GameObject.Find("ClansInvaderLogoMap") == null)
+                        {
+                            texture2D2 = new Texture2D(2, 2);
+                            data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
+                            texture2D2.LoadImage(data);
+                            go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
+                            go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                            go.name = "ClansInvaderLogoMap";
+                        }
+                        else
+                        {
+                            go = GameObject.Find("ClansInvaderLogoMap");
+                            data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/" + invaderclan.Name + "Logo.png");
+                            texture2D2 = new Texture2D(2, 2);
+                            texture2D2.LoadImage(data);
+                            go.GetComponent<Renderer>().material.mainTexture = texture2D2;
+                        }
+                        ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { invaderclan, go });
+                    }
+                }
 
-                if (GameObject.Find("DelphiLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/DelphiLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "DelphiLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("DelphiLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Delphi"), go });
-
-                if (GameObject.Find("ElysiaLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ElysiaLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "ElysiaLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("ElysiaLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Elysia"), go });
-
-                if (GameObject.Find("HanseLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/HanseLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "HanseLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("HanseLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Hanse"), go });
-
-                if (GameObject.Find("JarnFolkLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/JarnFolkLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "JarnFolkLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("JarnFolkLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("JarnFolk"), go });
-
-                if (GameObject.Find("TortugaLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/TortugaLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "TortugaLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("TortugaLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Tortuga"), go });
-
-                if (GameObject.Find("ValkyrateLogoMap") == null)
-                {
-                    texture2D2 = new Texture2D(2, 2);
-                    data = File.ReadAllBytes($"{InnerSphereMap.ModDirectory}/Logos/ValkyrateLogo.png");
-                    texture2D2.LoadImage(data);
-                    go = UnityEngine.Object.Instantiate(__instance.restorationLogo);
-                    go.GetComponent<Renderer>().material.mainTexture = texture2D2;
-                    go.name = "ValkyrateLogoMap";
-                }
-                else
-                {
-                    go = GameObject.Find("ValkyrateLogoMap");
-                }
-                ReflectionHelper.InvokePrivateMethode(__instance, "PlaceLogo", new object[] { FactionEnumeration.GetFactionByName("Valkyrate"), go });
             }
             catch (Exception e) {
                 Logger.LogError(e);


### PR DESCRIPTION
Remove the old hardcoding of placing the faction logo with a more generic version that uses the settings json to define what factions and logos to place.

Also removed the various faction RGB settings from the settings class since they are no longer used (vanilla code and the factiondefs now do this)